### PR TITLE
variation selector support

### DIFF
--- a/sample/index.js
+++ b/sample/index.js
@@ -15,7 +15,7 @@ app.get('/', async (req, res) => {
 
   context.fillStyle = '#000000';
   context.font = '30px serif';
-  await wt.fillTextWithTwemoji(context, 'test😉', 10, 50);
+  await wt.fillTextWithTwemoji(context, 'test😉test✨️', 10, 50);
 
   context.fillStyle = '#888888';
   context.font = '18px serif';

--- a/src/utils/splitEntitiesFromText.js
+++ b/src/utils/splitEntitiesFromText.js
@@ -14,14 +14,16 @@ module.exports = function splitEntitiesFromText (text) {
   const textEntities = [];
   
   twemojiEntities.forEach((twemoji) => {
-    textEntities.push(
-      unparsedText.slice(0, twemoji.indices[0] - lastTwemojiIndice)
-    );
-
-    textEntities.push(twemoji);
-
-    unparsedText = unparsedText.slice(twemoji.indices[1] - lastTwemojiIndice);
-    lastTwemojiIndice = twemoji.indices[1];
+    if (twemoji.url) {
+      textEntities.push(
+        unparsedText.slice(0, twemoji.indices[0] - lastTwemojiIndice)
+      );
+  
+      textEntities.push(twemoji);
+  
+      unparsedText = unparsedText.slice(twemoji.indices[1] - lastTwemojiIndice);
+      lastTwemojiIndice = twemoji.indices[1];
+    }
   });
 
   textEntities.push(unparsedText);

--- a/src/utils/splitEntitiesFromText.js
+++ b/src/utils/splitEntitiesFromText.js
@@ -14,16 +14,16 @@ module.exports = function splitEntitiesFromText (text) {
   const textEntities = [];
   
   twemojiEntities.forEach((twemoji) => {
+    textEntities.push(
+      unparsedText.slice(0, twemoji.indices[0] - lastTwemojiIndice)
+    );
+
     if (twemoji.url) {
-      textEntities.push(
-        unparsedText.slice(0, twemoji.indices[0] - lastTwemojiIndice)
-      );
-  
       textEntities.push(twemoji);
-  
-      unparsedText = unparsedText.slice(twemoji.indices[1] - lastTwemojiIndice);
-      lastTwemojiIndice = twemoji.indices[1];
     }
+
+    unparsedText = unparsedText.slice(twemoji.indices[1] - lastTwemojiIndice);
+    lastTwemojiIndice = twemoji.indices[1];
   });
 
   textEntities.push(unparsedText);


### PR DESCRIPTION
いくつかのemojiで、直前のUnicode文字をemojiとして扱うことを指示する`U+FE0F`という異体字セレクタ(variation selector)をつけるものがあります。
その場合に、`twemoji-parser`によって、urlが""のオブジェクトが追加されており、
何もない""のurlに対して、`loadTwemojiImageByUrl`しているため、`ENOENT, No such file or directory ''`エラーが発生することがありました。
https://github.com/cagpie/node-canvas-with-twemoji/blob/master/src/drawTextWithTwemoji.js#L71

URLが存在しない場合、`loadTwemojiImageByUrl`しないことでそのエラーを発生しない挙動に修正しました。

異体字セレクタ(variation selector)についての参考
- https://stackoverflow.com/questions/38100329/what-does-u-ufe0f-in-an-emoji-mean-is-it-the-same-if-i-delete-it