### PR TITLE
fix: unlock node-canvas version:

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "cagpie <cagpie@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "canvas": "2.6.1",
+    "canvas": "^2.6.1",
     "twemoji": "^13.1.0"
   }
 }


### PR DESCRIPTION
Otherwise, it will force NPM to install an additional version if it doesn't match a version of the project.

Because of an internal incompatibility between some node-canvas versions, this will result in `TypeError` when image loaded by v2.6.1 will be used in 2d context from v2.9.1