### PR TITLE
update twemoji to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "canvas": "2.6.1",
-    "twemoji": "^13.1.0"
+    "twemoji": "^14.0.2"
   }
 }

--- a/sample/index.js
+++ b/sample/index.js
@@ -38,8 +38,12 @@ app.get('/', async (req, res) => {
   context.textAlign = "right";
   await wt.fillTextWithTwemoji(context, 'right 😳', 190, 350);
 
+  context.textAlign = "center";
+  await wt.fillTextWithTwemoji(context, 'v14 🫶', 100, 400);
+
   if (req.query.text) {
-    await wt.fillTextWithTwemoji(context, req.query.text, 10, 400);
+    context.textAlign = "center";
+    await wt.fillTextWithTwemoji(context, req.query.text, 100, 450);
   }
 
   const b64 = canvas.toDataURL().split(',');


### PR DESCRIPTION
- Unicode v14の絵文字に対応 https://lets-emoji.com/unicode14-emoji/
- maxcdnに関しては、twemojiの方は対応されましたが、twemoji_parserの方は対応されてないです https://github.com/twitter/twemoji-parser
- https://twemoji.maxcdn.com/ は、現在jsDeliverがホストしてるので、特に変更なしで良さそうです

<img width="228" alt="スクリーンショット 2023-01-19 12 33 36" src="https://user-images.githubusercontent.com/37304826/213349873-2c492fdd-1d7a-4b57-b3cb-8a283d30585a.png">
